### PR TITLE
Add SecuSpark to Free/Paid Cybersecurity Courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ We would keep adding relevant learning references when we find them informative 
 4. [ISC2 CC - Free entry-level cybersecurity certification](https://www.isc2.org/certifications/cc) - Exam voucher is free under the "One Million Certified in Cybersecurity" program in some regions.
 5. [Microsoft SC-900 Fundamentals](https://learn.microsoft.com/en-us/certifications/security-compliance-and-identity-fundamentals/)
 6. [Cisco Networking Academy - free cybersecurity courses](https://www.netacad.com/cybersecurity)
+7. [SecuSpark - Gamified practice for CompTIA Security+, CySA+, PenTest+, SecAI+](https://www.secuspark.com/) - 7,500+ human-written practice questions with mock exams and spaced-repetition flashcards. Free tier.
 
 ## Free/Paid Cybersecurity Labs
 1. [hackthebox](https://referral.hackthebox.com/mzAlUIY) - Recommended


### PR DESCRIPTION
Adds SecuSpark to "Free/Paid Cybersecurity Courses" as item 7, matching the existing entry format.

SecuSpark is gamified certification prep for CompTIA Security+, CySA+, PenTest+, and SecAI+: 7,500+ human-written practice questions, full mock exams, and spaced-repetition (FSRS) flashcards, with a free tier. Listed as free/paid since the core practice loop is free and unlimited use is a paid tier — same shape as several existing entries.

(Note: this PR originally pushed an empty diff by mistake — now rebased on current main with the actual one-line addition.)

Disclosure: I'm the founder of SecuSpark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)