### PR TITLE
docs(osint): add browser-local metadata viewer

### DIFF
--- a/awesome-osint-learning-resources.md
+++ b/awesome-osint-learning-resources.md
@@ -108,6 +108,9 @@ OSINT is the practice of collecting and analyzing publicly-available information
 37. [InVID / WeVerify plugin](https://www.invid-project.eu/) - Video / image verification.
 38. [FotoForensics](https://fotoforensics.com/) - Image forensics.
 
+[Metadata Remover Viewer](https://metadataremover.ai/metadata-viewer) - Browser-local EXIF, GPS, XMP, and IPTC inspection; files stay in the browser.
+Metadata can be missing, stripped, edited, or forged; corroborate it with provenance and visual/context evidence.
+
 ### Dark-web / underground (use caution, legality varies)
 39. [Ahmia (Tor search)](https://ahmia.fi/)
 40. [Intelligence X](https://intelx.io/)


### PR DESCRIPTION
Adds a browser-local EXIF/GPS/XMP/IPTC viewer to the geolocation and imagery section, plus a reminder that metadata should be corroborated with provenance and visual/context evidence.

Disclosure: I maintain Metadata Remover. This is a free resource contribution and does not request payment or a reciprocal link.